### PR TITLE
Add battery_station to docs

### DIFF
--- a/docs/battery_station.md
+++ b/docs/battery_station.md
@@ -1,0 +1,10 @@
+---
+id: battery-station
+title: Battery Station
+---
+
+Some synapses are currently connecting the dots.
+Please come back a bit later.
+
+Feel free to create a prediction market that determines when the first version
+of this page is ready :)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ title: Roadmap
 
 ## Where are we now?
 
-Currently Zeitgeist is in pre-alpha with its [Battery Park](./battery-park)
+Currently Zeitgeist is in beta with its [Battery Station](./battery-station)
 testnet.
 
 ## Where are we going?
@@ -17,7 +17,7 @@ Items and priorities are liable to change.
 
 #### Q1
 
-- Launch of Beta-phase Battery Park testnet.
+- Launch of alpha-phase Battery Park testnet.
 - Launch of testnet incentivization program.
 - Launch of the Proto trading app.
 
@@ -25,19 +25,21 @@ Items and priorities are liable to change.
 
 - Work on second version of prediction markets using Substrate primitives.
 - Work on the decentralized court system.
-- Work on integrating Futarcy into Zeitgeist's native governance framework
 - Launch of community and ambassador program.
 
 #### Q3
 
-- Launch of the Zeitgeist mainnet and of the ZTG token.
-- Start work on Zeitgeist DAOs that can use the same futarchy methods that
-  govern Zeitgeist.
 - Explore new trading methods.
+- Liqudity Mining program.
+- Implement and test parachain compability
+- Launch of beta-phase Battery Station testnet.
 
 #### Q4
 
-- Liqudity Mining program.
+- Work on integrating Futarchy into Zeitgeist's native governance framework
+- Start work on Zeitgeist DAOs that can use the same futarchy methods that
+  govern Zeitgeist.
+- Launch of the Zeitgeist mainnet and of the ZTG token.
 - Implement DAO framework on Zeitgeist.
 - Implement crosschain functionality through becoming a Kusama parachain.
 

--- a/docs/using-the-faucet.md
+++ b/docs/using-the-faucet.md
@@ -3,20 +3,19 @@ id: using-the-faucet
 title: Using the Faucet
 ---
 
-Zeitgeist's test network [Battery Park](./battery-park) uses the ZBP token,
-instead of the ZTG. ZBP is provided to users through a frictioned faucet on
+Zeitgeist's test network [Battery Station](./battery-station) uses the ZBS token,
+instead of the ZTG. ZBS is provided to users through a frictioned faucet on
 Discord in order to allow for testing and experimentation.
 
-__NOTE:__ Due to the presence of a click-farm attack on our faucet we needed to take an
-extra measure to protect the integrity of the Kusama Derby campaign. For this reason,
-we decided to put the faucet behind a $2.00 paywall. All of the proceeds will be donated to India
-COVID Relief Funds. We hope you understand. The faucet can now be accessed from [this link](https://launchpass.com/kusama-derby-faucet/faucet).
+To gain access to the faucet, a NFT from one of three different collections
+is required. Keep an eye on the announcements to not miss the opportunity
+to obtain limited access to the faucet and consequently the beta.
 
-## Getting ZBP
+## Getting ZBS
 
 ### Using the !drip command
 
-The normal way to get ZBP from the faucet is to use the !drip command.
+The normal way to get ZBS from the faucet is to use the !drip command.
 
 - First create a new Zeitgeist account (standard Substrate account) using the
   Polkadot-JS Extension that is available
@@ -26,52 +25,8 @@ The normal way to get ZBP from the faucet is to use the !drip command.
   an account.
 - Go to Zeitgeist's Discord server and enter into the #faucet channel.
 - Copy your address from the extension, ensure that it's in Substrate generic
-  format (begins with a "5").
+  or Battery Station format (begins with either a "5" or "d").
 - Type in `!drip <address>` to the faucet channel.
-- The faucet should respond that it sent you some ZBP.
+- The faucet should respond that it sent you some ZBS.
 - After completing this you will have a 24 hour cooldown until you can get more
-  ZBP.
-
-### Using the !claim command
-
-As a special bonus to KSM holders during the
-[Kusama Derby](https://proto.zeitgeist.pm/kusama-derby), the faucet will allow
-any account that held KSM on the snapshot day of May 11, 2021 to claim an
-equivalent amount of ZBP for usage on the testnet.
-
-In order to make the claim you will need to sign a message using your KSM
-account. There may be multiple ways to do this but for this guide we show you
-using Polkadot-JS Apps, which is available [here](https://polkadot.js.org/apps).
-
-Go to Apps and switch the network to Kusama.
-
-![apps kusama](./../static/img/apps_kusama.png)
-
-Go to the "Developer" and select "Sign and Verify".
-
-![sign and verify](./../static/img/sign_and_verify.png)
-
-Now it is expected that you have a Zeitgeist account (Substrate standard
-account) ready, if you do not please follow the instructions
-[here](./how-to-participate-in-derby#create-a-zeitgeist-account) to create one.
-
-Copy and paste your Zeitgeist account address into the field that says "sign the
-following data". Click "Sign message" and confirm any prompts that ask for
-confirmation.
-
-Now you should have a hex string that looks like this:
-
-`0xbee763936b767363bce2f102b87e4da48a74732d94385e29e72c0cb77e39f1680b7edd006721887807169d0122c77a471e8cae1cb710cfd7839a41e07909ff82`
-
-Now you will go to the faucet and type the following command, using your own KSM
-address, ZTG address, and signed message as the arguments:
-
-```
-!claim <ztg_address> <ksm_address> <signed_message>
-```
-
-If all is successful you will see the faucet respond that it sent you an
-equivalent amount of ZBP as your Kusama account had on the snapshot day. This
-claim can only be done once.
-
-![faucet claim](./../static/img/faucet_claim.png)
+  ZBS.

--- a/docs/using-zeitgeist-markets.md
+++ b/docs/using-zeitgeist-markets.md
@@ -10,8 +10,8 @@ assets.
 
 An asset in Zeitgeist could be:
 
-- units of the ZTG token (on the Battery Park testnet, this token is known as
-  ZBP - but in SDK and CLI commands, and in this page, both ZTG and ZBP are
+- units of the ZTG token (on the Battery Station testnet, this token is known as
+  ZBS - but in SDK and CLI commands, and in this page, both ZTG and ZBS are
   called ZTG)
 - An outcome asset, representing 1 ZTG only _once_ the market has finalised and
   _if_ the corresponding outcome is what the market resolved to.

--- a/sidebars.js
+++ b/sidebars.js
@@ -2,7 +2,7 @@ module.exports = {
   someSidebar: {
     Documentation: [
       'getting-started',
-      'battery-park',
+      'battery-station',
       'faq',
       'prediction-markets',
       'using-zeitgeist-markets',
@@ -12,7 +12,6 @@ module.exports = {
       'applications',
       'roadmap',
       'comparisons',
-      'how-to-participate-in-derby',
       'using-the-faucet',
       'troubleshooting'
     ],


### PR DESCRIPTION
Also replaces "Battery Park" with "Battery Station", "ZBP" with "ZBS", removes deprecated docs from the sidebar and some other minor changes