### PR TITLE
Fix double logo and highlighting in navbar

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,6 @@
 ---
 id: getting-started
 title: Getting Started
-sidebar_label: Getting Started
-slug: /
 ---
 
 Zeitgeist is an evolving blockchain for prediction markets and futarchy. The

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ const config = {
             position: 'left',
             value: '<a href="https://docs.zeitgeist.pm" class="navbar-title"><span class="navbar-title--zeitgeist">Zeitgeist</span><span class="navbar-title--blue">.</span><span class="navbar-title--documentation">Documentation</span></a>',
           },
-          {to: 'docs', label: 'Getting Started', position: 'right'},
+          {to: 'docs/getting-started', label: 'Getting Started', position: 'right'},
           {to: 'docs/category/learn', label: 'Learn', position: 'right'},
           {to: 'docs/category/build', label: 'Build', position: 'right'},
           {to: 'docs/faq', label: 'FAQ', position: 'right'},

--- a/i18n/ru/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,8 +1,6 @@
 ---
 id: getting-started
 title: Getting Started
-sidebar_label: Getting Started
-slug: /
 ---
 
 Zeitgeist is an evolving blockchain for prediction markets and futarchy. The

--- a/i18n/ru/docusaurus-theme-classic/navbar.json
+++ b/i18n/ru/docusaurus-theme-classic/navbar.json
@@ -1,8 +1,4 @@
 {
-  "title": {
-    "message": "Zeitgeist Documentation",
-    "description": "The title in the navbar"
-  },
   "item.label.Docs": {
     "message": "Docs",
     "description": "Navbar item with label Docs"

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,8 +1,6 @@
 ---
 id: getting-started
 title: Getting Started
-sidebar_label: Getting Started
-slug: /
 ---
 
 Zeitgeist is an evolving blockchain for prediction markets and futarchy. The

--- a/i18n/zh-CN/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh-CN/docusaurus-theme-classic/navbar.json
@@ -1,8 +1,4 @@
 {
-  "title": {
-    "message": "Zeitgeist Documentation",
-    "description": "The title in the navbar"
-  },
   "item.label.Docs": {
     "message": "项目文档",
     "description": "Navbar item with label Docs"

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,8 +1,6 @@
 ---
 id: getting-started
 title: Getting Started
-sidebar_label: Getting Started
-slug: /
 ---
 
 Zeitgeist is an evolving blockchain for prediction markets and futarchy. The core functions of the Zeitgeist network include methods for creating, betting on, and resolving [prediction markets][]. However, it also consists of a [governance protocol][] which sways the direction of the network, a [decentralized court][] to handle disputes, and utilities for operating [futarchic organizations][].


### PR DESCRIPTION
Currently, the Zeitgeist logo is displayed twice in the localized docs, and the highlighting of the chapters is broken. This PR fixes both.
<img width="1335" alt="Screenshot 2022-07-08 at 14 02 39" src="https://user-images.githubusercontent.com/49552287/177988553-eaccc8ba-188c-4556-ba04-3d32f9f323e1.png">

