### PR TITLE
Added link to faucet on Battery Station page

### DIFF
--- a/docs/basic/battery_station.mdx
+++ b/docs/basic/battery_station.mdx
@@ -570,7 +570,7 @@ See [Zeitgeist Beta](./zeitgeist-beta) for details.
 
 ## Faucet
 
-We operate a faucet, that can be used to receive the native Zeitgeist currency
+We operate a faucet on our [Discord server](https://discord.com/invite/xv8HuA4s8v), that can be used to receive the native Zeitgeist currency
 for the Battery Station testnet, ZBS (Zeitgeist Battery Station), which is
 required for numerous interactions with Battery Station. You will need an
 account to retrieve ZBS.

--- a/docs/basic/battery_station.mdx
+++ b/docs/basic/battery_station.mdx
@@ -570,10 +570,11 @@ See [Zeitgeist Beta](./zeitgeist-beta) for details.
 
 ## Faucet
 
-We operate a faucet on our [Discord server](https://discord.com/invite/xv8HuA4s8v), that can be used to receive the native Zeitgeist currency
-for the Battery Station testnet, ZBS (Zeitgeist Battery Station), which is
-required for numerous interactions with Battery Station. You will need an
-account to retrieve ZBS.
+We operate a faucet on our
+[Discord server](https://discord.com/invite/xv8HuA4s8v), that can be used to
+receive the native Zeitgeist currency for the Battery Station testnet, ZBS
+(Zeitgeist Battery Station), which is required for numerous interactions with
+Battery Station. You will need an account to retrieve ZBS.
 
 There are numerous ways to generate an account, we suggest to use
 [Polkadot{.js} extension](https://github.com/polkadot-js/extension) though,


### PR DESCRIPTION
As requested in this parity PR, I've added a link to the discord faucet on the battery station page.

https://github.com/paritytech/contracts-ui/pull/519

